### PR TITLE
If hostfile does not exist when using -f, try in ~/.hss - Added support for server specific logging via -O

### DIFF
--- a/common.h
+++ b/common.h
@@ -55,6 +55,7 @@ extern struct hss_config {
     int common_options_argc;
     const char **common_options_argv;
     char *output_file;
+    bool split_server_logs;
     int concurrency;
 } *pconfig;
 

--- a/main.c
+++ b/main.c
@@ -154,6 +154,7 @@ void usage(const char *msg) {
                 "  -u user        the default user name to use when connecting to the remote server\n"
                 "  -c opts        specify the common ssh options (i.e. '-p 22 -i identity_file')\n"
                 "  -o file        write remote command output to a file\n"
+                "  -O             write remote command output to log file per server\n"
                 "  -i             force use a vi-style line editing interface\n"
                 "  -v             be more verbose\n"
                 "  -V             show program version\n"
@@ -179,8 +180,8 @@ void
 parse_opts(int argc, char **argv) {
     int ret;
     int opt;
-    
-    const char *short_opts = "hif:H:c:u:o:l:vV";
+
+    const char *short_opts = "hif:H:c:u:o:Ol:vV";
 
     pconfig = calloc(1, sizeof(struct hss_config));
 
@@ -213,6 +214,9 @@ parse_opts(int argc, char **argv) {
                 break;
             case 'o':
                 pconfig->output_file = new_string(optarg);
+                break;
+            case 'O':
+                pconfig->split_server_logs = true;
                 break;
             case 'v':
                 pconfig->verbose = true;


### PR DESCRIPTION
I needed 2 things:
	
1. use a default folder named .hss/ in home to use for the host files
    current version you type: "hss -f ~/hostgroup"
   I want to type
   "hss hostgroup" from any folder, the program will look for the file in <home>/.hss

2. in the .hss folder, I wanted a subfolder per server, holding the log files of the output
    file name like ~/.hss/ipaddr/date_per_day.log 
    The idea is to be able to review or tail easily
